### PR TITLE
feat: add a unique user id to track unique users

### DIFF
--- a/packages/web/src/generic.ts
+++ b/packages/web/src/generic.ts
@@ -35,7 +35,7 @@ export function inject(
 
     let e = (e) => e,
         t = document.currentScript,
-        n = (null == t ? void 0 : t.dataset.endpoint) || (null != t ? "http://localhost:3001/api/db" : "https://www.dappling.network/api/db");
+        n = (null == t ? void 0 : t.dataset.endpoint) || (null != t ? "https://www.dappling.network/api/db" : "https://www.dappling.network/api/db");
       
     async function i({ type: i, data: o, options: a }) {
       var r, l;

--- a/packages/web/src/generic.ts
+++ b/packages/web/src/generic.ts
@@ -27,9 +27,15 @@ export function inject(
   // script.src = src;
   script.text = `'use strict';
   !(function () {
+    let uniqueId = localStorage.getItem('dapplingAnalytics');
+    if (!uniqueId) {
+      uniqueId = Math.random().toString(36).substring(2, 15) + Math.random().toString(36).substring(2, 15);
+      localStorage.setItem('dapplingAnalytics', uniqueId);
+    }
+
     let e = (e) => e,
         t = document.currentScript,
-        n = (null == t ? void 0 : t.dataset.endpoint) || (null != t ? "https://www.dappling.network/api/db" : "https://www.dappling.network/api/db");
+        n = (null == t ? void 0 : t.dataset.endpoint) || (null != t ? "http://localhost:3001/api/db" : "https://www.dappling.network/api/db");
       
     async function i({ type: i, data: o, options: a }) {
       var r, l;
@@ -47,6 +53,7 @@ export function inject(
         f = {
           o: d,
           sv: '0.1.2',
+          uid: uniqueId,
           sdkn:
             null != (r = null == t ? void 0 : t.getAttribute('data-sdkn'))
               ? r


### PR DESCRIPTION
Addresses part of dappling.network issue [#535](https://github.com/alwaysbegrowing/dappling.network/issues/535)

Add a unique id to users' local storage in order to track individuals separate from page views

![CleanShot 2023-08-14 at 13 13 11](https://github.com/alwaysbegrowing/dapplingAnalytics/assets/99197390/5ec8976c-f034-4ed3-af64-94ae702fccfb)
